### PR TITLE
Implement AsyncEvents

### DIFF
--- a/Endpoints/Game.cs
+++ b/Endpoints/Game.cs
@@ -15,7 +15,7 @@ public sealed class Game : Endpoint
 	///     - title: string game title.
 	///  - paused: boolean, true when gameplay is paused (not the same as stepping.)
 	/// </summary>
-	public event EventHandler<GameResultEventArgs>? OnStarted;
+	public AsyncEvent<GameResultEventArgs> OnStarted = new ();
 
 	/// <summary>
 	/// - game: null or an object with properties:
@@ -24,7 +24,7 @@ public sealed class Game : Endpoint
 	///     - title: string game title.
 	///  - paused: boolean, true when gameplay is paused (not the same as stepping.)
 	/// </summary>
-	public event EventHandler<GameResultEventArgs>? OnQuit;
+	public AsyncEvent<GameResultEventArgs> OnQuit = new ();
 
 	/// <summary>
 	/// Game paused (game.pause)
@@ -37,7 +37,7 @@ public sealed class Game : Endpoint
 	///     - version: string disc version.
 	///     - title: string game title.
 	/// </summary>
-	public event EventHandler<GameResultEventArgs>? OnPaused;
+	public AsyncEvent<GameResultEventArgs> OnPaused = new();
 
 	/// <summary>
 	/// Game resumed (game.pause)
@@ -50,7 +50,7 @@ public sealed class Game : Endpoint
 	///     - version: string disc version.
 	///     - title: string game title.
 	/// </summary>
-	public event EventHandler<GameResultEventArgs>? OnResumed;
+	public AsyncEvent<GameResultEventArgs> OnResumed = new();
 
 	/// <summary>
 	/// Reset emulation (game.reset)
@@ -97,25 +97,5 @@ public sealed class Game : Endpoint
 			Name = _ppsspp.ClientName,
 			Version = _ppsspp.ClientVersion,
 		});
-	}
-
-	internal void Started(JsonElement root)
-	{
-		OnStarted?.Invoke(this, root.Deserialize<GameResultEventArgs>() ?? new GameResultEventArgs());
-	}
-
-	internal void Quit(JsonElement root)
-	{
-		OnQuit?.Invoke(this, root.Deserialize<GameResultEventArgs>() ?? new GameResultEventArgs());
-	}
-
-	internal void Paused(JsonElement root)
-	{
-		OnPaused?.Invoke(this, root.Deserialize<GameResultEventArgs>() ?? new GameResultEventArgs());
-	}
-
-	internal void Resumed(JsonElement root)
-	{
-		OnResumed?.Invoke(this, root.Deserialize<GameResultEventArgs>() ?? new GameResultEventArgs());
 	}
 }

--- a/Endpoints/Input.cs
+++ b/Endpoints/Input.cs
@@ -8,18 +8,8 @@ public sealed class Input : Endpoint
 	{
 	}
 
-	public event EventHandler<InputButtonResult>? OnButtonChange;
-	public event EventHandler<InputAnalogResult>? OnAnalogChange;
-	
-	public void ButtonChanged(JsonElement root)
-	{
-		OnButtonChange?.Invoke(this, root.Deserialize<InputButtonResult>() ?? new InputButtonResult());
-	}
-
-	public void AnalogChanged(JsonElement root)
-	{
-		OnAnalogChange?.Invoke(this, root.Deserialize<InputAnalogResult>() ?? new InputAnalogResult());
-	}
+	public AsyncEvent<InputButtonResult> OnButtonChange = new();
+	public AsyncEvent<InputAnalogResult> OnAnalogChange = new();
 }
 
 

--- a/MonitorFileOpen/Program.cs
+++ b/MonitorFileOpen/Program.cs
@@ -8,32 +8,21 @@ uint? functionAddress = null;
 
 try
 {
-	//await ppsspp.AutoConnectAsync();
-	await ppsspp.ConnectAsync(new Uri("ws://192.168.1.8:45333/debugger"));
+	await ppsspp.AutoConnectAsync();
+	//await ppsspp.ConnectAsync(new Uri("ws://127.0.0.1:45333/debugger"));
+	//await ppsspp.ConnectAsync(new Uri("ws://127.0.0.1:52809/debugger"));
+	//await ppsspp.ConnectAsync(new Uri("ws://10.211.55.3:52809/debugger")); //WindowsVM
+	//await ppsspp.ConnectAsync(new Uri("ws://192.168.1.31:45333/debugger"));
+
+	//Game_OnStartedAsync(null, new GameResultEventArgs());
 
 	var result = await ppsspp.Game.VersionAsync();
 
 	Console.WriteLine($"Connected to {result.Name} version {result.Version}");
 
-	var result2 = await ppsspp.Hle.FunctionListAsync();
-	
-	if (!result2.Functions.Any())
-	{
-		throw new Exception("No functions, not playing any game?");
-	}
+	ppsspp.Game.OnStarted.Add(Game_OnStartedAsync);
 
-	functionAddress = result2.Functions.SingleOrDefault(x => x.Name == "zz_sceIoOpen")?.Address;
-
-	if (functionAddress == null)
-	{
-		throw new Exception("Function stub for sceIoOpen not found... game never calls it?");
-	}
-	
-	Console.WriteLine($"Found func stub for sceIoOpen at 0x{functionAddress.Value:X8}");
-
-	ppsspp.Cpu.OnStep += (_, cpuSteppingResult) => CpuOnStep(cpuSteppingResult, functionAddress.Value);
-	
-	await ppsspp.Cpu.AddBreakpointAsync(functionAddress.Value);
+    ppsspp.Game.OnQuit.Add(Game_OnQuitAsync);
 	
 	await Task.Delay(-1);
 }
@@ -41,8 +30,8 @@ catch (Exception ex)
 {
 	await Console.Error.WriteLineAsync($"Something went wrong: {ex.Message}");
 	
-	if(ex.Data.Contains("ReceivedMessage") && ex.Data["ReceivedMessage"] is JsonDocument)
-		Debug.WriteLine(((JsonDocument)ex.Data["ReceivedMessage"]!).RootElement.GetRawText());
+	if(ex.Data.Contains("ReceivedMessage"))
+        await Console.Error.WriteLineAsync(ex.Data["ReceivedMessage"]?.ToString());
 }
 finally
 {
@@ -50,7 +39,36 @@ finally
 		await ppsspp.Cpu.RemoveBreakpointAsync(functionAddress.Value);
 }
 
-async void CpuOnStep(CpuSteppingResult cpuSteppingResult, uint address)
+async Task Game_OnQuitAsync(object? sender, GameResultEventArgs e)
+{
+    if (functionAddress.HasValue)
+        await ppsspp.Cpu.RemoveBreakpointAsync(functionAddress.Value);
+}
+
+async Task Game_OnStartedAsync(object? sender, GameResultEventArgs e)
+{
+   var result2 = await ppsspp.Hle.FunctionListAsync();
+
+    if (!result2.Functions.Any())
+    {
+        throw new Exception("No functions, not playing any game?");
+    }
+
+    functionAddress = result2.Functions.SingleOrDefault(x => x.Name == "zz_sceIoOpen")?.Address;
+
+    if (functionAddress == null)
+    {
+        throw new Exception("Function stub for sceIoOpen not found... game never calls it?");
+    }
+
+    Console.WriteLine($"Found func stub for sceIoOpen at 0x{functionAddress.Value:X8}");
+
+    ppsspp.Cpu.OnStep.Add((_, cpuSteppingResult) => Cpu_OnStep(cpuSteppingResult, functionAddress.Value));
+
+    await ppsspp.Cpu.AddBreakpointAsync(functionAddress.Value);
+}
+
+async Task Cpu_OnStep(CpuSteppingResult cpuSteppingResult, uint address)
 {
 	if (cpuSteppingResult.Pc != address)
 	{
@@ -72,7 +90,7 @@ async void CpuOnStep(CpuSteppingResult cpuSteppingResult, uint address)
 	{
 		Console.Error.WriteLine($"Failed to log open? {ex.Message}");
 
-		if (ex.Data.Contains("ReceivedMessage") && ex.Data["ReceivedMessage"] is JsonDocument)
-			Debug.WriteLine(((JsonDocument)ex.Data["ReceivedMessage"]!).RootElement.GetRawText());
-	}
+		if (ex.Data.Contains("ReceivedMessage"))
+            await Console.Error.WriteLineAsync(ex.Data["ReceivedMessage"]?.ToString());
+    }
 }

--- a/ResultMessage.cs
+++ b/ResultMessage.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace ppsspp_api;
 
-public class GameResultEventArgs : EventArgs
+public class GameResultEventArgs : MessageEventArgs
 {
 	[JsonPropertyName("title")]
 	public string Title { get; set; }
@@ -159,10 +159,10 @@ public class InputAnalogResult : MessageEventArgs
 	public string Stick { get; set; }
 	
 	[JsonPropertyName("x")]
-	public int X { get; set; }
+	public double X { get; set; }
 	
 	[JsonPropertyName("y")]
-	public int Y { get; set; }
+	public double Y { get; set; }
 }
 
 

--- a/ppsspp-api.csproj
+++ b/ppsspp-api.csproj
@@ -17,7 +17,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
         <LangVersion>default</LangVersion>
-        <Version>0.0.2-pre</Version>
+        <Version>0.0.3-pre</Version>
         <Copyright>Copyright (c) 2023 Pierce Andjelkovic</Copyright>
         <PackageProjectUrl>https://github.com/archanox/ppsspp-api</PackageProjectUrl>
         <RepositoryUrl>https://github.com/archanox/ppsspp-api</RepositoryUrl>


### PR DESCRIPTION
This is an attempt to get to the bottom of a perceived race condition.

Duplicate messages are being raised as an event causing already expired tickets to be attempted to be reprocessed.

Locks during breakpoints are never released as a duplicate set breakpoints are coming through with no pending ticket, as it was parsed previously.